### PR TITLE
Export `$NIX_PATH`

### DIFF
--- a/conf.d/halostatue_fish_nix.fish
+++ b/conf.d/halostatue_fish_nix.fish
@@ -19,13 +19,13 @@ end
 
 if not set -q NIX_PROFILES
     # Set up the per-user profile. This part should be kept in sync with nixpkgs:nixos/modules/programs/shell.nix
-    set NIX_LINK $HOME/.nix-profile
+    set -l NIX_LINK $HOME/.nix-profile
 
     # Append ~/.nix-defexpr/channels to $NIX_PATH so that <nixpkgs> paths work when the user has fetched the Nixpkgs channel.
     if set -q NIX_PATH
-        set NIX_PATH $NIX_PATH:$HOME/.nix-defexpr/channels
+        set -x NIX_PATH $NIX_PATH:$HOME/.nix-defexpr/channels
     else
-        set NIX_PATH $HOME/.nix-defexpr/channels
+        set -x NIX_PATH $HOME/.nix-defexpr/channels
     end
 
     # Set up environment.


### PR DESCRIPTION
[`$NIX_PATH` should be exported](https://github.com/NixOS/nix/blob/1c3ccba0f5e658fa5d593ddef8aaaf6728f945a5/scripts/nix-profile.sh.in#L11). Note: don't be deceived by https://github.com/NixOS/nix/commit/ec9dd9a5aeb9b7fca170d86b8906ffac7e5ef057, the commit never entered 2.3 which is the latest version of Nix.

Also, `$NIX_LINK` should only be available inside the script.